### PR TITLE
chore: Use .prow.yaml instead of .aicoe-ci.yaml

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,5 +1,4 @@
 check:
-  - thoth-precommit
   - thoth-build
 build:
   build-stratergy: Dockerfile

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,17 @@
+presubmits:
+  - name: pre-commit
+    decorate: true
+    skip_report: false
+    always_run: true
+    context: aicoe-ci/prow/pre-commit
+    spec:
+      containers:
+        - image: quay.io/thoth-station/thoth-precommit-py38:v0.12.5
+          command:
+            - "pre-commit"
+            - "run"
+            - "--all-files"
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu: "2"


### PR DESCRIPTION
Part of: https://github.com/operate-first/toolbox/issues/18

/cc @goern @harshad16 