### PR TITLE
fix: Speed up kustomize build by checking overlays only

### DIFF
--- a/scripts/test-kustomize-build
+++ b/scripts/test-kustomize-build
@@ -14,7 +14,7 @@ echo '#!/bin/sh' >$KUSTOMIZE_PLUGIN_HOME/viaduct.ai/v1/ksops/ksops
 chmod +x $KUSTOMIZE_PLUGIN_HOME/viaduct.ai/v1/ksops/ksops
 
 # and check all the sub directories with manifests...
-k=$(find . -name kustomization.yaml)
+k=$(find . -regex ".*/overlays/.*kustomization.yaml")
 
 for d in $k; do
     if [[ $(dirname $d) == *odh-manifests* ]]; then


### PR DESCRIPTION
Part of: https://github.com/operate-first/toolbox/issues/16

Skips `base` and `components` and check `overlays` only - we should be consuming manifests from overlays only anyways.