### PR TITLE
feat: Make test-kustomiz-build test changes only

### DIFF
--- a/scripts/test-kustomize-build
+++ b/scripts/test-kustomize-build
@@ -5,6 +5,15 @@ trap 'echo "Aborting due to errexit on line $LINENO. Exit code: $?" >&2' ERR
 set -o errtrace
 set -o pipefail
 
+# In CI test changes only
+if [ ! -z "$PULL_BASE_SHA" ] && [ ! -z "$PULL_PULL_SHA" ]; then
+    echo "Checking changes in range $PULL_BASE_SHA..$PULL_PULL_SHA only."
+    bases=$(git diff --name-only $PULL_BASE_SHA $PULL_PULL_SHA | cut -d "/" -f1 | sort | uniq)
+else
+    echo "Checking all overlays."
+    bases="."
+fi
+
 # Let's ignore the secrets...
 
 export KUSTOMIZE_PLUGIN_HOME=/tmp/new_plugin_dir
@@ -14,7 +23,7 @@ echo '#!/bin/sh' >$KUSTOMIZE_PLUGIN_HOME/viaduct.ai/v1/ksops/ksops
 chmod +x $KUSTOMIZE_PLUGIN_HOME/viaduct.ai/v1/ksops/ksops
 
 # and check all the sub directories with manifests...
-k=$(find . -regex ".*/overlays/.*kustomization.yaml")
+k=$(for i in $(echo "$bases"); do find $i -regex ".*/overlays/.*kustomization.yaml"; done)
 
 for d in $k; do
     if [[ $(dirname $d) == *odh-manifests* ]]; then


### PR DESCRIPTION
Resolves: https://github.com/operate-first/toolbox/issues/16
Workaround for: https://github.com/operate-first/apps/issues/764

Makes `test-kustomize-build` to test changes only.

If the script is executed from Prow context it should have access to [these env variables](https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables) including `$PULL_BASE_SHA` and `$PULL_PULL_SHA`

This change fetches list of modified files from the git history, selects the base folder (`cut -d "/" -f1`) and makes find locate overlays only in that base folder.

This makes the test to finally test the changes only:
```
$ git checkout pr/761
$ export PULL_PULL_SHA=ad3fcd0136e1074cd5394c353b707d1954150a50
$ export PULL_BASE_SHA=b5b880974c29db225485c41900f1c73c010e7cf2
$ ../toolbox/scripts/test-kustomize-build
Checking changes in range b5b880974c29db225485c41900f1c73c010e7cf2..ad3fcd0136e1074cd5394c353b707d1954150a50 only.
checking cluster-scope/overlays/dev
checking cluster-scope/overlays/moc/common
checking cluster-scope/overlays/moc/infra
checking cluster-scope/overlays/moc/zero
checking cluster-scope/overlays/moc/curator
```
