### PR TITLE
Adding mini CLI script for cloning repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN \
     curl -o /usr/local/bin/yq -L https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 && \
     chmod +x /usr/local/bin/yq && \
     # Install Operate First easy repo cloning tool
-    curl -o /usr/local/bin/o1-clone https://github.com/quaid/o1-tools/releases/download/${O1-CLONE_VERSION}/o1-clone && \
+    curl -o /usr/local/bin/o1-clone https://github.com/operate-first/toolbox/blob/master/scripts/o1-clone && \
     chmod +x /usr/local/bin/o1-clone
 
 COPY scripts/* /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ARG HELM_VERSION="v3.4.1"
 ARG HELM_SECRETS_VERSION="3.4.1"
 ARG CONFTEST_VERSION="0.21.0"
 ARG YQ_VERSION="v4.6.1"
+ARG O1-CLONE_VERSION="v0.1"
 
 LABEL maintainer="Operate First" \
     name="operate-first/opf-toolbox" \
@@ -24,7 +25,8 @@ LABEL maintainer="Operate First" \
     version.helm="${HELM_VERSION}" \
     version.helm_secrets="${HELM_SECRETS_VERSION}" \
     version.ksops="${KSOPS_VERSION}" \
-    version.sops="${SOPS_VERSION}"
+    version.sops="${SOPS_VERSION}" \
+    version.o1-clone="${O1-CLONE_VERSION}"
 
 # Copy ksops and kustomize from builder
 COPY --from=ksops-builder /go/bin/kustomize /usr/local/bin/kustomize
@@ -45,6 +47,9 @@ RUN \
     # Install yq
     curl -o /usr/local/bin/yq -L https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 && \
     chmod +x /usr/local/bin/yq
+    # Install Operate First easy repo cloning tool
+    curl -o /usr/local/bin/o1-clone https://github.com/quaid/o1-tools/releases/download/${O1-CLONE_VERSION}/o1-clone && \
+    chmod +x /usr/local/bin/o1-clone
 
 COPY scripts/* /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN \
     # Install yq
     curl -o /usr/local/bin/yq -L https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 && \
     chmod +x /usr/local/bin/yq
-    
+
 COPY scripts/* /usr/local/bin/
 
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ LABEL maintainer="Operate First" \
     version.helm="${HELM_VERSION}" \
     version.helm_secrets="${HELM_SECRETS_VERSION}" \
     version.ksops="${KSOPS_VERSION}" \
-    version.sops="${SOPS_VERSION}" \
+    version.sops="${SOPS_VERSION}"
 
 # Copy ksops and kustomize from builder
 COPY --from=ksops-builder /go/bin/kustomize /usr/local/bin/kustomize

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ ARG HELM_VERSION="v3.4.1"
 ARG HELM_SECRETS_VERSION="3.4.1"
 ARG CONFTEST_VERSION="0.21.0"
 ARG YQ_VERSION="v4.6.1"
-ARG O1-CLONE_VERSION="v0.1"
 
 LABEL maintainer="Operate First" \
     name="operate-first/opf-toolbox" \
@@ -26,7 +25,6 @@ LABEL maintainer="Operate First" \
     version.helm_secrets="${HELM_SECRETS_VERSION}" \
     version.ksops="${KSOPS_VERSION}" \
     version.sops="${SOPS_VERSION}" \
-    version.o1-clone="${O1-CLONE_VERSION}"
 
 # Copy ksops and kustomize from builder
 COPY --from=ksops-builder /go/bin/kustomize /usr/local/bin/kustomize
@@ -46,11 +44,8 @@ RUN \
     chmod +x /usr/local/bin/conftest && \
     # Install yq
     curl -o /usr/local/bin/yq -L https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 && \
-    chmod +x /usr/local/bin/yq && \
-    # Install Operate First easy repo cloning tool
-    curl -o /usr/local/bin/o1-clone https://github.com/operate-first/toolbox/blob/master/scripts/o1-clone && \
-    chmod +x /usr/local/bin/o1-clone
-
+    chmod +x /usr/local/bin/yq
+    
 COPY scripts/* /usr/local/bin/
 
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN \
     chmod +x /usr/local/bin/conftest && \
     # Install yq
     curl -o /usr/local/bin/yq -L https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 && \
-    chmod +x /usr/local/bin/yq
+    chmod +x /usr/local/bin/yq && \
     # Install Operate First easy repo cloning tool
     curl -o /usr/local/bin/o1-clone https://github.com/quaid/o1-tools/releases/download/${O1-CLONE_VERSION}/o1-clone && \
     chmod +x /usr/local/bin/o1-clone

--- a/scripts/o1-clone
+++ b/scripts/o1-clone
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Script to clone from github.com/operate-first/ and setup the environment
+# (C) 2021 Karsten Wade <kwade@redhat.com> <quaid@iquaid.org
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# This barebones script is not very clever, because it is just trying to
+# clone a repo and set it up according to Operate First community practices:
+# https://URL_FOR_COMMUNITY_PRACTICES_NEEDED
+#
+# Use:
+# ./o1-tools/bin/o1-clone repo-name
+#
+# For example:
+# ./o1-tools/bin/o1-clone community-handbook
+#
+#
+# Let's presume you want something from the /operate-first/ org and take in
+# the first bash variable as the repo name:
+git clone git@github.com:operate-first/$1.git
+# Enter the project to prepare the environment
+cd $1
+# Install pre-commit hooks and whatever else it does
+pre-commit install
+#
+# That's it for now, what other environment activities could we do here?


### PR DESCRIPTION
- Not finding a similar tool and tired already of forgetting to do my `pre-commit install` step when cloning a repo, >
- It's in a repo so it can be maintained, moved	around,	etc.
- When I asked in Slack #general if such a tool existed, I found out it didn't and it was suggested (thanks @tumido f>
- IIUC,	my patch to the	Dockerfile should pull in v0.1 of this bash script, drop it where it's in the user's $PATH, and makes sure the file is executable
- Patches to this patch, and to the upstream script, are very welcome
- Also, suggestions on what I can do better in v0.2 are welcome; my bash skills are basic and rusty, happy for any help and tips
- My concept here is that we may want to have a handful of individual tools, and then be able call them by `o1 toolname OPTIONS ARGUMENT TARGET`-sort of thing, as a way to ease the life of contributors, and help keep our work net and tidy. :)

Signed-of by: Karsten Wade <kwade@redhat.com> <quaid@iquaid.org>

## Related Issues and Dependencies

None

## This introduces a breaking change

- [ ] Yes
- [X] No

(It shouldn't! but I didn't test the Dockerfile)

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Adding a mini CLI tool for more easily cloning Operate First project repositories, then setting up the proper environment for the newly cloned repo.

Currently, it takes a repo name, clones it, and runs `pre-commit install` to install pre-commit hooks.

`o1-clone REPONAME`

This script can be extended for any common newly cloned repo actions

## Description

Adding the variable, Dockerfile description element, and call to download and include the specified version of the tool (https://github.com/quaid/o1-tools/releases/tag/v0.1) in the resulting Toolbox build.