### PR TITLE
feat: Add make, nodejs, prow binaries and bump to fedora 34

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 ARG KSOPS_VERSION="v2.5.5"
 FROM quay.io/viaductoss/ksops:$KSOPS_VERSION as ksops-builder
-FROM registry.fedoraproject.org/f32/fedora-toolbox:32
+FROM gcr.io/k8s-prow/label_sync:latest as labels-sync-builder
+FROM gcr.io/k8s-prow/peribolos:latest as peribolos-builder
+
+FROM registry.fedoraproject.org/fedora-toolbox:34
 
 ENV XDG_DATA_HOME=/usr/share/.local/share \
     XDG_CACHE_HOME=/usr/share/.cache \
@@ -26,9 +29,16 @@ LABEL maintainer="Operate First" \
     version.ksops="${KSOPS_VERSION}" \
     version.sops="${SOPS_VERSION}"
 
-# Copy ksops and kustomize from builder
+# Copy ksops, kustomize, labels_sync and peribolos from builders
 COPY --from=ksops-builder /go/bin/kustomize /usr/local/bin/kustomize
 COPY --from=ksops-builder /go/src/github.com/viaduct-ai/kustomize-sops/*  $KUSTOMIZE_PLUGIN_PATH/viaduct.ai/v1/ksops/
+COPY --from=labels-sync-builder /app/label_sync/app.binary /usr/bin/labels_sync
+COPY --from=peribolos-builder /app/prow/cmd/peribolos/app.binary /usr/bin/peribolos
+
+# Install additional dependecies and tools
+RUN dnf install -y openssl make npm \
+    && dnf clean all \
+    && rm -rf /var/cache/yum
 
 RUN \
     # Install Sops

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This is a Operate-First toolbox that comprises of commonly used tooling to suppl
 ### Create your toolbox container
 
 ```shell
-$ toolbox create --image quay.io/operate-first/opf-toolbox:v0.4.0
+$ toolbox create --image quay.io/operate-first/opf-toolbox:v0.4.1
 Created container: opf-toolbox
-Enter with: toolbox enter --container opf-toolbox-v0.4.0
+Enter with: toolbox enter --container opf-toolbox-v0.4.1
 ```
 
 This will create a container called `opf-toolbox-<version-id>`.
@@ -17,7 +17,7 @@ This will create a container called `opf-toolbox-<version-id>`.
 ### Enter the toolbox
 
 ```shell
-$ toolbox enter --container opf-toolbox-v0.4.0
+$ toolbox enter --container opf-toolbox-v0.4.1
 ```
 
 ### Tools included
@@ -29,6 +29,9 @@ $ toolbox enter --container opf-toolbox-v0.4.0
 - Helm Secrets
 - Conftest
 - YQ
+- Make
+- NPM and nodejs
+- Prow's label_sync and peribolos
 
 ### Debugging Tips
 


### PR DESCRIPTION
## Related Issues and Dependencies

Part of: https://github.com/operate-first/operate-first.github.io/issues/277
Resolves: https://github.com/operate-first/common/pull/10#issuecomment-885981540

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Adds additional tools like `make`, `nodejs` and `npm`. Also packages Prow's `label_sync` and `peribolos` binaries.

Bumps base image to Fedora toolbox 34

A `0.4.1` release should follow a merge of this PR. This PR anticipates it, so it also updates version references in the readme.