### PR TITLE
feat: Add pre-commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,11 @@ COPY --from=labels-sync-builder /app/label_sync/app.binary /usr/bin/labels_sync
 COPY --from=peribolos-builder /app/prow/cmd/peribolos/app.binary /usr/bin/peribolos
 
 # Install additional dependecies and tools
-RUN dnf install -y openssl make npm \
+RUN dnf install -y openssl make npm pre-commit \
     && dnf clean all \
     && rm -rf /var/cache/yum
+
+ENV PRE_COMMIT_HOME=/tmp
 
 RUN \
     # Install Sops

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This is a Operate-First toolbox that comprises of commonly used tooling to suppl
 ### Create your toolbox container
 
 ```shell
-$ toolbox create --image quay.io/operate-first/opf-toolbox:v0.4.1
+$ toolbox create --image quay.io/operate-first/opf-toolbox:v0.4.2
 Created container: opf-toolbox
-Enter with: toolbox enter --container opf-toolbox-v0.4.1
+Enter with: toolbox enter --container opf-toolbox-v0.4.2
 ```
 
 This will create a container called `opf-toolbox-<version-id>`.
@@ -17,7 +17,7 @@ This will create a container called `opf-toolbox-<version-id>`.
 ### Enter the toolbox
 
 ```shell
-$ toolbox enter --container opf-toolbox-v0.4.1
+$ toolbox enter --container opf-toolbox-v0.4.2
 ```
 
 ### Tools included
@@ -32,6 +32,7 @@ $ toolbox enter --container opf-toolbox-v0.4.1
 - Make
 - NPM and nodejs
 - Prow's label_sync and peribolos
+- pre-commit
 
 ### Debugging Tips
 


### PR DESCRIPTION
Adds `pre-commit` into the toolbox (no idea why it was missing all the time)

Required by: https://github.com/operate-first/operate-first.github.io/pull/286

Version string in `README.md` is also updated in preparation for a release 