### PR TITLE
feat: Add support for skip_kinds.txt file in script

### DIFF
--- a/scripts/test-kubeval-validation
+++ b/scripts/test-kubeval-validation
@@ -22,6 +22,9 @@ mkdir -p $KUSTOMIZE_PLUGIN_HOME/viaduct.ai/v1/ksops/
 echo '#!/bin/sh' >$KUSTOMIZE_PLUGIN_HOME/viaduct.ai/v1/ksops/ksops
 chmod +x $KUSTOMIZE_PLUGIN_HOME/viaduct.ai/v1/ksops/ksops
 
+# Download current skip_kinds.txt
+skipkindslist=`curl https://raw.githubusercontent.com/operate-first/schema-store/main/skip_kinds.txt`
+
 # User can specify custom include/exclude regex
 if [ -z "$INCLUDE" ]; then
     INCLUDE=".*/overlays/.*kustomization.yaml"
@@ -39,7 +42,7 @@ for d in $k; do
     fi
 
     echo checking $(dirname $d)
-    kustomize build --enable-alpha-plugins $(dirname $d) | kubeval --strict --ignore-missing-schemas --schema-location=https://raw.githubusercontent.com/operate-first/schema-store/main/schemas 2>&1
+    kustomize build --enable-alpha-plugins $(dirname $d) | kubeval --strict --skip-kinds $skipkindslist --schema-location=https://raw.githubusercontent.com/operate-first/schema-store/main/schemas 2>&1
 done
 
 #end.


### PR DESCRIPTION
## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Adding support for skip_kinds.txt file in toolbox. This should allow us to use this against CRDs which do not have valid schemas.
Part of: https://github.com/operate-first/SRE/issues/107
## Description

<!--- Describe your changes in detail -->

