### PR TITLE
feat: Add missing schemas flag to kubeval validation

### DIFF
--- a/scripts/test-kubeval-validation
+++ b/scripts/test-kubeval-validation
@@ -42,7 +42,7 @@ for d in $k; do
     fi
 
     echo checking $(dirname $d)
-    kustomize build --enable-alpha-plugins $(dirname $d) | kubeval --strict --skip-kinds $skipkindslist --schema-location=https://raw.githubusercontent.com/operate-first/schema-store/main/schemas 2>&1
+    kustomize build --enable-alpha-plugins $(dirname $d) | kubeval --strict --skip-kinds $skipkindslist --schema-location=https://raw.githubusercontent.com/operate-first/schema-store/main/schemas --ignore-missing-schemas 2>&1
 done
 
 #end.


### PR DESCRIPTION
Signed-off-by: Michal Drla <mdrla@redhat.com>

## Related Issues and Dependencies

…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements


## Description

Part of: https://github.com/open-services-group/scrum/issues/6

Since the kubeval currently fails due to missing schemas on new CRD resources, there is added `--ignore-missing-schemas` flag.